### PR TITLE
Queue Resource Release

### DIFF
--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -315,7 +315,8 @@ handle_info(Request, State) ->
 
 %% @hidden
 -spec terminate(term(), state()) -> ok.
-terminate(_Reason, _State) -> ok.
+terminate(_Reason, State=#state{queue = QID}) -> 
+  apns_queue:stop(QID).
 
 %% @hidden
 -spec code_change(term(), state(), term()) -> {ok, state()}.


### PR DESCRIPTION
When close a apns connection, the queue resource doesn't release,which leads to a lot of useless apns queue left in system that cannot be GC.
Add apns_queue:stop in apns_connection:terminate can fix it.
